### PR TITLE
Add a Gitter chat room

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 GitHub is the world's largest code repository and home to countless open source projects, including many that we actively contribute to. We also participate in several open source mentorship programs.
 
-If you are looking for an opportunity to work on an open source project with a GitHub member, please look through the [project idea list][project] and apply through one of the [available programs][program]. Feel free to [open an issue](https://github.com/github/mentorships/labels/question) to ask questions or discuss other ideas.
+If you are looking for an opportunity to work on an open source project with a GitHub member, please look through the [project idea list][project] and apply through one of the [available programs][program]. Feel free to [open an issue](https://github.com/github/mentorships/labels/question) or [join chat](https://gitter.im/github/mentorships) to ask questions or discuss other ideas.
+
+[![Join the chat at https://gitter.im/github/mentorships](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/github/mentorships
+?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [project]: https://github.com/github/mentorships/labels/project
 [program]: https://github.com/github/mentorships/labels/program


### PR DESCRIPTION
This adds https://gitter.im/github/mentorships as the chat channel to ask general questions for all our mentorships.

/cc @johndbritton 
